### PR TITLE
sticky nav buttons

### DIFF
--- a/wp-content/themes/voiceofoc/partials/nav-global.php
+++ b/wp-content/themes/voiceofoc/partials/nav-global.php
@@ -29,6 +29,7 @@ if ( ! is_single() && ! is_singular() || ! of_get_option( 'main_nav_hide_article
 				?>
 				<div class="nav-right">
 					<?php
+					
 					/* Check to display Social Media Icons */
 					if ( of_get_option( 'show_header_social') ) { ?>
 						<ul id="header-social" class="social-icons visible-desktop">

--- a/wp-content/themes/voiceofoc/partials/nav-sticky.php
+++ b/wp-content/themes/voiceofoc/partials/nav-sticky.php
@@ -153,7 +153,7 @@ $site_name = ( of_get_option( 'nav_alt_site_name', false ) ) ? of_get_option( 'n
 									<a class="donate-link" href="http://voiceofoc.us9.list-manage.com/subscribe?u=21b45ca592433dae9870e9e71&id=6100b0e74b">
 										<span><?php echo "Subscribe"; ?></span>
 									</a>
-								</li><?php
+								</li> <?php
 								}
 							}
 							if (has_nav_menu('global-nav')) {


### PR DESCRIPTION
To finish up #11 -

1. Added donate/subscribe buttons to mobile nav header by pulling in the Largo nav-sticky.php file. 

2. Pulled in the nav-global.php file from Largo and removed donate button to make sure it only shows up in the mobile view.

3. Changed button background color to ocOrange.