### PR TITLE
adding FB pixel

### DIFF
--- a/wp-content/themes/voiceofoc/functions.php
+++ b/wp-content/themes/voiceofoc/functions.php
@@ -207,3 +207,24 @@ else {
 	}
 }
 add_action( 'wp_head', 'voiceofoc_tronc_DFP_ads' );
+
+function voiceofoc_facebook_pixel() {
+	?>
+		<!-- Facebook Pixel Code -->
+		<script>
+			!function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+			n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+			n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+			t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window,
+			document,'script','https://connect.facebook.net/en_US/fbevents.js');
+			fbq('init', '1873216659661772'); // Insert your pixel ID here.
+			fbq('track', 'PageView');
+		</script>
+		<noscript>
+			<img height="1" width="1" style="display:none" src="https://www.facebook.com/tr?id=1873216659661772&ev=PageView&noscript=1"/>
+		</noscript>
+		<!-- DO NOT MODIFY -->
+		<!-- End Facebook Pixel Code -->
+	<?php
+}
+add_action('wp_head', 'voiceofoc_facebook_pixel');


### PR DESCRIPTION
This adds a Facebook pixel with VoOC's pixel tracking ID to establish a baseline for measuring specific events.

@benlk Can this be deployed directly to the live site?